### PR TITLE
Update FHIR and MIMIC tutorials to be based on the updated feature type detection

### DIFF
--- a/fhir.ipynb
+++ b/fhir.ipynb
@@ -29,7 +29,12 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-05-15T13:47:00.200599Z",
+     "start_time": "2024-05-15T13:46:58.309571Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import ehrapy as ep"
@@ -37,19 +42,13 @@
    "id": "8df675df4777689a"
   },
   {
-   "cell_type": "markdown",
-   "id": "9a1ff75b",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "id": "4b27e7ec",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-04-20T14:32:11.608323Z",
-     "start_time": "2024-04-20T14:32:00.915480Z"
+     "end_time": "2024-05-15T13:47:25.133835Z",
+     "start_time": "2024-05-15T13:47:08.699868Z"
     }
    },
    "outputs": [],
@@ -76,12 +75,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "id": "b036b8e1",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-04-20T14:32:31.229130Z",
-     "start_time": "2024-04-20T14:32:11.609110Z"
+     "end_time": "2024-05-15T13:48:00.239611Z",
+     "start_time": "2024-05-15T13:47:43.088018Z"
     }
    },
    "outputs": [],
@@ -92,12 +91,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "id": "40d14b21",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-04-20T14:32:42.165701Z",
-     "start_time": "2024-04-20T14:32:41.387360Z"
+     "end_time": "2024-05-15T13:48:00.636957Z",
+     "start_time": "2024-05-15T13:48:00.241776Z"
     }
    },
    "outputs": [],
@@ -109,20 +108,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "ab1920a0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-04-20T14:32:43.842021Z",
-     "start_time": "2024-04-20T14:32:43.779379Z"
+     "end_time": "2024-05-15T13:48:00.651642Z",
+     "start_time": "2024-05-15T13:48:00.637702Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "AnnData object with n_obs × n_vars = 1000 × 69\n    var: 'ehrapy_column_type'\n    layers: 'original'"
+      "text/plain": "AnnData object with n_obs × n_vars = 1000 × 68\n    layers: 'original'"
      },
-     "execution_count": 13,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -134,19 +133,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001B[1;35m2024-04-20 16:32:52,875\u001B[0m - \u001B[1;34mroot\u001B[0m \u001B[1;37mINFO - Feature types have been inferred and stored in adata.var['feature_type']. PLEASE CHECK and adjust if necessary using adata.var['feature_type']['feature1']='corrected_type'.\u001B[0m\n"
+      "❗ Feature resource.suppliedItem.quantity.value was detected as a categorical feature stored numerically. Please verify.\n"
      ]
     },
     {
      "data": {
-      "text/plain": "\u001B[1m Detected feature types for AnnData object with 1000 obs and 69 vars\u001B[0m\n╠══ 📅\u001B[1m Date features\u001B[0m\n╠══ 📐\u001B[1m Numerical features\u001B[0m\n║   ╠══ resource.payment.amount.value\n║   ╠══ resource.suppliedItem.quantity.value\n║   ╠══ resource.total.value\n║   ╚══ resource.valueQuantity.value\n╚══ 🗂️\u001B[1m Categorical features\u001B[0m\n    ╠══ fullUrl (1000 categories)\n    ╠══ patientId (5 categories)\n    ╠══ request.method (1 categories)\n    ╠══ request.url (16 categories)\n    ╠══ resource.abatementDateTime (21 categories)\n    ╠══ resource.authoredOn (23 categories)\n    ╠══ resource.billablePeriod.end (84 categories)\n    ╠══ resource.billablePeriod.start (86 categories)\n    ╠══ resource.birthDate (2 categories)\n    ╠══ resource.claim.reference (69 categories)\n    ╠══ resource.class.code (2 categories)\n    ╠══ resource.class.system (1 categories)\n    ╠══ resource.code.text (142 categories)\n    ╠══ resource.context.period.end (43 categories)\n    ╠══ resource.context.period.start (43 categories)\n    ╠══ resource.created (43 categories)\n    ╠══ resource.custodian.reference (6 categories)\n    ╠══ resource.date (43 categories)\n    ╠══ resource.deceasedDateTime (1 categories)\n    ╠══ resource.distinctIdentifier (5 categories)\n    ╠══ resource.effectiveDateTime (85 categories)\n    ╠══ resource.encounter.reference (44 categories)\n    ╠══ resource.expirationDate (3 categories)\n    ╠══ resource.facility.reference (6 categories)\n    ╠══ resource.gender (1 categories)\n    ╠══ resource.intent (1 categories)\n    ╠══ resource.issued (85 categories)\n    ╠══ resource.location.reference (5 categories)\n    ╠══ resource.lotNumber (5 categories)\n    ╠══ resource.manufactureDate (3 categories)\n    ╠══ resource.maritalStatus.text (1 categories)\n    ╠══ resource.medicationCodeableConcept.text (10 categories)\n    ╠══ resource.multipleBirthBoolean (1 categories)\n    ╠══ resource.occurrenceDateTime (18 categories)\n    ╠══ resource.onsetDateTime (37 categories)\n    ╠══ resource.outcome (1 categories)\n    ╠══ resource.patient.reference (2 categories)\n    ╠══ resource.payment.amount.currency (1 categories)\n    ╠══ resource.performedPeriod.end (73 categories)\n    ╠══ resource.performedPeriod.start (66 categories)\n    ╠══ resource.period.end (44 categories)\n    ╠══ resource.period.start (44 categories)\n    ╠══ resource.prescription.reference (26 categories)\n    ╠══ resource.primarySource (1 categories)\n    ╠══ resource.provider.reference (12 categories)\n    ╠══ resource.recorded (1 categories)\n    ╠══ resource.recordedDate (37 categories)\n    ╠══ resource.referral.reference (1 categories)\n    ╠══ resource.requester.reference (4 categories)\n    ╠══ resource.resourceType (16 categories)\n    ╠══ resource.serialNumber (5 categories)\n    ╠══ resource.serviceProvider.reference (6 categories)\n    ╠══ resource.status (7 categories)\n    ╠══ resource.subject.reference (2 categories)\n    ╠══ resource.suppliedItem.itemCodeableConcept.text (2 categories)\n    ╠══ resource.text.status (1 categories)\n    ╠══ resource.total.currency (1 categories)\n    ╠══ resource.type.text (4 categories)\n    ╠══ resource.use (1 categories)\n    ╠══ resource.vaccineCode.text (6 categories)\n    ╠══ resource.valueCodeableConcept.text (19 categories)\n    ╠══ resource.valueQuantity.code (24 categories)\n    ╠══ resource.valueQuantity.system (1 categories)\n    ╠══ resource.valueQuantity.unit (24 categories)\n    ╚══ resource.valueString (1 categories)\n",
-      "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Detected feature types for AnnData object with 1000 obs and 69 vars</span>\n╠══ 📅<span style=\"font-weight: bold\"> Date features</span>\n╠══ 📐<span style=\"font-weight: bold\"> Numerical features</span>\n║   ╠══ resource.payment.amount.value\n║   ╠══ resource.suppliedItem.quantity.value\n║   ╠══ resource.total.value\n║   ╚══ resource.valueQuantity.value\n╚══ 🗂️<span style=\"font-weight: bold\"> Categorical features</span>\n    ╠══ fullUrl (1000 categories)\n    ╠══ patientId (5 categories)\n    ╠══ request.method (1 categories)\n    ╠══ request.url (16 categories)\n    ╠══ resource.abatementDateTime (21 categories)\n    ╠══ resource.authoredOn (23 categories)\n    ╠══ resource.billablePeriod.end (84 categories)\n    ╠══ resource.billablePeriod.start (86 categories)\n    ╠══ resource.birthDate (2 categories)\n    ╠══ resource.claim.reference (69 categories)\n    ╠══ resource.class.code (2 categories)\n    ╠══ resource.class.system (1 categories)\n    ╠══ resource.code.text (142 categories)\n    ╠══ resource.context.period.end (43 categories)\n    ╠══ resource.context.period.start (43 categories)\n    ╠══ resource.created (43 categories)\n    ╠══ resource.custodian.reference (6 categories)\n    ╠══ resource.date (43 categories)\n    ╠══ resource.deceasedDateTime (1 categories)\n    ╠══ resource.distinctIdentifier (5 categories)\n    ╠══ resource.effectiveDateTime (85 categories)\n    ╠══ resource.encounter.reference (44 categories)\n    ╠══ resource.expirationDate (3 categories)\n    ╠══ resource.facility.reference (6 categories)\n    ╠══ resource.gender (1 categories)\n    ╠══ resource.intent (1 categories)\n    ╠══ resource.issued (85 categories)\n    ╠══ resource.location.reference (5 categories)\n    ╠══ resource.lotNumber (5 categories)\n    ╠══ resource.manufactureDate (3 categories)\n    ╠══ resource.maritalStatus.text (1 categories)\n    ╠══ resource.medicationCodeableConcept.text (10 categories)\n    ╠══ resource.multipleBirthBoolean (1 categories)\n    ╠══ resource.occurrenceDateTime (18 categories)\n    ╠══ resource.onsetDateTime (37 categories)\n    ╠══ resource.outcome (1 categories)\n    ╠══ resource.patient.reference (2 categories)\n    ╠══ resource.payment.amount.currency (1 categories)\n    ╠══ resource.performedPeriod.end (73 categories)\n    ╠══ resource.performedPeriod.start (66 categories)\n    ╠══ resource.period.end (44 categories)\n    ╠══ resource.period.start (44 categories)\n    ╠══ resource.prescription.reference (26 categories)\n    ╠══ resource.primarySource (1 categories)\n    ╠══ resource.provider.reference (12 categories)\n    ╠══ resource.recorded (1 categories)\n    ╠══ resource.recordedDate (37 categories)\n    ╠══ resource.referral.reference (1 categories)\n    ╠══ resource.requester.reference (4 categories)\n    ╠══ resource.resourceType (16 categories)\n    ╠══ resource.serialNumber (5 categories)\n    ╠══ resource.serviceProvider.reference (6 categories)\n    ╠══ resource.status (7 categories)\n    ╠══ resource.subject.reference (2 categories)\n    ╠══ resource.suppliedItem.itemCodeableConcept.text (2 categories)\n    ╠══ resource.text.status (1 categories)\n    ╠══ resource.total.currency (1 categories)\n    ╠══ resource.type.text (4 categories)\n    ╠══ resource.use (1 categories)\n    ╠══ resource.vaccineCode.text (6 categories)\n    ╠══ resource.valueCodeableConcept.text (19 categories)\n    ╠══ resource.valueQuantity.code (24 categories)\n    ╠══ resource.valueQuantity.system (1 categories)\n    ╠══ resource.valueQuantity.unit (24 categories)\n    ╚══ resource.valueString (1 categories)\n</pre>\n"
+      "text/plain": "\u001B[1m Detected feature types for AnnData object with 1000 obs and 68 vars\u001B[0m\n╠══ 📅\u001B[1m Date features\u001B[0m\n║   ╠══ resource.abatementDateTime\n║   ╠══ resource.authoredOn\n║   ╠══ resource.billablePeriod.end\n║   ╠══ resource.billablePeriod.start\n║   ╠══ resource.birthDate\n║   ╠══ resource.context.period.end\n║   ╠══ resource.context.period.start\n║   ╠══ resource.created\n║   ╠══ resource.date\n║   ╠══ resource.deceasedDateTime\n║   ╠══ resource.effectiveDateTime\n║   ╠══ resource.expirationDate\n║   ╠══ resource.issued\n║   ╠══ resource.manufactureDate\n║   ╠══ resource.occurrenceDateTime\n║   ╠══ resource.onsetDateTime\n║   ╠══ resource.performedPeriod.end\n║   ╠══ resource.performedPeriod.start\n║   ╠══ resource.period.end\n║   ╠══ resource.period.start\n║   ╠══ resource.recorded\n║   ╚══ resource.recordedDate\n╠══ 📐\u001B[1m Numerical features\u001B[0m\n║   ╠══ resource.distinctIdentifier\n║   ╠══ resource.lotNumber\n║   ╠══ resource.payment.amount.value\n║   ╠══ resource.serialNumber\n║   ╠══ resource.total.value\n║   ╚══ resource.valueQuantity.value\n╚══ 🗂️\u001B[1m Categorical features\u001B[0m\n    ╠══ fullUrl (1000 categories)\n    ╠══ patientId (5 categories)\n    ╠══ request.method (1 categories)\n    ╠══ request.url (16 categories)\n    ╠══ resource.claim.reference (126 categories)\n    ╠══ resource.class.code (3 categories)\n    ╠══ resource.class.system (1 categories)\n    ╠══ resource.code.text (125 categories)\n    ╠══ resource.custodian.reference (8 categories)\n    ╠══ resource.encounter.reference (57 categories)\n    ╠══ resource.facility.reference (8 categories)\n    ╠══ resource.gender (1 categories)\n    ╠══ resource.intent (1 categories)\n    ╠══ resource.location.reference (4 categories)\n    ╠══ resource.maritalStatus.text (2 categories)\n    ╠══ resource.medicationCodeableConcept.text (15 categories)\n    ╠══ resource.multipleBirthBoolean (1 categories)\n    ╠══ resource.outcome (1 categories)\n    ╠══ resource.patient.reference (2 categories)\n    ╠══ resource.payment.amount.currency (1 categories)\n    ╠══ resource.prescription.reference (70 categories)\n    ╠══ resource.primarySource (1 categories)\n    ╠══ resource.provider.reference (16 categories)\n    ╠══ resource.referral.reference (1 categories)\n    ╠══ resource.requester.reference (6 categories)\n    ╠══ resource.resourceType (16 categories)\n    ╠══ resource.serviceProvider.reference (8 categories)\n    ╠══ resource.status (8 categories)\n    ╠══ resource.subject.reference (2 categories)\n    ╠══ resource.suppliedItem.itemCodeableConcept.text (1 categories)\n    ╠══ resource.suppliedItem.quantity.value (1 categories)\n    ╠══ resource.text.status (1 categories)\n    ╠══ resource.total.currency (1 categories)\n    ╠══ resource.type.text (1 categories)\n    ╠══ resource.use (1 categories)\n    ╠══ resource.vaccineCode.text (5 categories)\n    ╠══ resource.valueCodeableConcept.text (5 categories)\n    ╠══ resource.valueQuantity.code (21 categories)\n    ╠══ resource.valueQuantity.system (1 categories)\n    ╚══ resource.valueQuantity.unit (21 categories)\n",
+      "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Detected feature types for AnnData object with 1000 obs and 68 vars</span>\n╠══ 📅<span style=\"font-weight: bold\"> Date features</span>\n║   ╠══ resource.abatementDateTime\n║   ╠══ resource.authoredOn\n║   ╠══ resource.billablePeriod.end\n║   ╠══ resource.billablePeriod.start\n║   ╠══ resource.birthDate\n║   ╠══ resource.context.period.end\n║   ╠══ resource.context.period.start\n║   ╠══ resource.created\n║   ╠══ resource.date\n║   ╠══ resource.deceasedDateTime\n║   ╠══ resource.effectiveDateTime\n║   ╠══ resource.expirationDate\n║   ╠══ resource.issued\n║   ╠══ resource.manufactureDate\n║   ╠══ resource.occurrenceDateTime\n║   ╠══ resource.onsetDateTime\n║   ╠══ resource.performedPeriod.end\n║   ╠══ resource.performedPeriod.start\n║   ╠══ resource.period.end\n║   ╠══ resource.period.start\n║   ╠══ resource.recorded\n║   ╚══ resource.recordedDate\n╠══ 📐<span style=\"font-weight: bold\"> Numerical features</span>\n║   ╠══ resource.distinctIdentifier\n║   ╠══ resource.lotNumber\n║   ╠══ resource.payment.amount.value\n║   ╠══ resource.serialNumber\n║   ╠══ resource.total.value\n║   ╚══ resource.valueQuantity.value\n╚══ 🗂️<span style=\"font-weight: bold\"> Categorical features</span>\n    ╠══ fullUrl (1000 categories)\n    ╠══ patientId (5 categories)\n    ╠══ request.method (1 categories)\n    ╠══ request.url (16 categories)\n    ╠══ resource.claim.reference (126 categories)\n    ╠══ resource.class.code (3 categories)\n    ╠══ resource.class.system (1 categories)\n    ╠══ resource.code.text (125 categories)\n    ╠══ resource.custodian.reference (8 categories)\n    ╠══ resource.encounter.reference (57 categories)\n    ╠══ resource.facility.reference (8 categories)\n    ╠══ resource.gender (1 categories)\n    ╠══ resource.intent (1 categories)\n    ╠══ resource.location.reference (4 categories)\n    ╠══ resource.maritalStatus.text (2 categories)\n    ╠══ resource.medicationCodeableConcept.text (15 categories)\n    ╠══ resource.multipleBirthBoolean (1 categories)\n    ╠══ resource.outcome (1 categories)\n    ╠══ resource.patient.reference (2 categories)\n    ╠══ resource.payment.amount.currency (1 categories)\n    ╠══ resource.prescription.reference (70 categories)\n    ╠══ resource.primarySource (1 categories)\n    ╠══ resource.provider.reference (16 categories)\n    ╠══ resource.referral.reference (1 categories)\n    ╠══ resource.requester.reference (6 categories)\n    ╠══ resource.resourceType (16 categories)\n    ╠══ resource.serviceProvider.reference (8 categories)\n    ╠══ resource.status (8 categories)\n    ╠══ resource.subject.reference (2 categories)\n    ╠══ resource.suppliedItem.itemCodeableConcept.text (1 categories)\n    ╠══ resource.suppliedItem.quantity.value (1 categories)\n    ╠══ resource.text.status (1 categories)\n    ╠══ resource.total.currency (1 categories)\n    ╠══ resource.type.text (1 categories)\n    ╠══ resource.use (1 categories)\n    ╠══ resource.vaccineCode.text (5 categories)\n    ╠══ resource.valueCodeableConcept.text (5 categories)\n    ╠══ resource.valueQuantity.code (21 categories)\n    ╠══ resource.valueQuantity.system (1 categories)\n    ╚══ resource.valueQuantity.unit (21 categories)\n</pre>\n"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -158,34 +157,11 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-20T14:32:52.914050Z",
-     "start_time": "2024-04-20T14:32:52.855166Z"
+     "end_time": "2024-05-15T13:48:02.144915Z",
+     "start_time": "2024-05-15T13:48:02.091641Z"
     }
    },
    "id": "f4b42a0963eddc92"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "outputs": [],
-   "source": [
-    "adata.var[\"feature_type\"][\"resource.abatementDateTime\"] = \"date\"\n",
-    "adata.var[\"feature_type\"][\"resource.authoredOn\"] = \"date\"\n",
-    "adata.var[\"feature_type\"][\"resource.billablePeriod.end\"] = \"date\"\n",
-    "adata.var[\"feature_type\"][\"resource.billablePeriod.start\"] = \"date\"\n",
-    "adata.var[\"feature_type\"][\"resource.birthDate\"] = \"date\"\n",
-    "adata.var[\"feature_type\"][\"resource.context.period.end\"] = \"date\"\n",
-    "adata.var[\"feature_type\"][\"resource.context.period.start\"] = \"date\"\n",
-    "adata.var[\"feature_type\"][\"resource.date\"] = \"date\""
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-04-20T14:44:05.763949Z",
-     "start_time": "2024-04-20T14:44:05.755016Z"
-    }
-   },
-   "id": "745e434402e4f676"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
- Closes #26 
- Due to the improved date detection in `ep.ad.infer_feature_types`, all date features in the FHIR dataset in the respective tutorial are now detected automatically, allowing us to remove the manual correction.
- Small changes to the beginning of the MIMIC introduction tutorial: Previously, we referred to the "ehrapy_feature_type" column stored in `var`. This annotation will be removed with the new PR, hence we need to delete it from the tutorial as well.