### PR TITLE
feat: CONSORT-style branching in cohort_tracking tutorial

### DIFF
--- a/cohort_tracking.ipynb
+++ b/cohort_tracking.ipynb
@@ -424,18 +424,47 @@
     "\n",
     "ct.plot_flowchart(\n",
     "    title=\"Cohort flowchart\",\n",
-    "    arrow_size=0.75,\n",
-    "    bbox_kwargs={\"fc\": \"lightgreen\"},\n",
-    "    arrowprops_kwargs={\"color\": \"black\"},\n",
+    "    node_color=\"#d9ead3\",\n",
+    "    edge_color=\"black\",\n",
     ")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "## Branching cohorts (CONSORT-style flowcharts)\n",
+    "\n",
+    "Real studies rarely process one cohort linearly: participants are screened, enrolled, randomized into arms, and followed up. Pass `parent=` (a step label or 0-based index) to `CohortTracker.__call__` to branch off a previously tracked step. The default `parent=None` still continues from the previous step, so linear pipelines are unchanged.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
    "outputs": [],
-   "source": []
+   "source": [
+    "enrolled = edata[edata.obs.time_in_hospital >= 2]\n",
+    "arm_a = enrolled[enrolled.obs.race == \"Caucasian\"]\n",
+    "arm_b = enrolled[enrolled.obs.race == \"AfricanAmerican\"]\n",
+    "\n",
+    "ct_branched = ep.tl.CohortTracker(edata, categorical=[\"gender\", \"race\", \"medicaid\"])\n",
+    "ct_branched(edata, label=\"Screened\")\n",
+    "ct_branched(enrolled, label=\"Enrolled\", operations_done=\"time_in_hospital >= 2\")\n",
+    "ct_branched(arm_a, label=\"Caucasian\", operations_done=\"stratify by race\", parent=\"Enrolled\")\n",
+    "ct_branched(arm_b, label=\"AfricanAmerican\", operations_done=\"stratify by race\", parent=\"Enrolled\")\n",
+    "ct_branched(arm_a[arm_a.obs.medicaid], label=\"Caucasian / Medicaid\", operations_done=\"medicaid only\", parent=\"Caucasian\")\n",
+    "ct_branched(arm_b[arm_b.obs.medicaid], label=\"AA / Medicaid\", operations_done=\"medicaid only\", parent=\"AfricanAmerican\")\n",
+    "\n",
+    "ct_branched.plot_flowchart(title=\"CONSORT-style flowchart\", width=820, height=560)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`plot_flowchart` returns a HoloViews/Bokeh overlay, so the rendered diagram is interactive (pan, zoom, hover) directly in the notebook. To save it as a standalone HTML report use `hv.save(ct_branched.plot_flowchart(), \"flowchart.html\")`.\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Pairs with theislab/ehrapy#1077.

- Updates the customization snippet to the new `plot_flowchart` kwargs (`node_color` / `edge_color` replacing `arrow_size`/`bbox_kwargs`/`arrowprops_kwargs`).
- Adds a "Branching cohorts (CONSORT-style flowcharts)" section showing `parent=` to fork the tracker into a CONSORT-style diagram with two race-stratified arms and a Medicaid sub-cohort each.

## Test plan
- [x] notebook executes end-to-end via `jupyter nbconvert --execute`